### PR TITLE
feat: bootstrap deterministic agent lab monorepo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "deterministic-agent-lab",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": "corepack enable pnpm",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
+    }
+  }
+}

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  ignorePatterns: ['dist', 'node_modules', '.turbo', '.next']
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.4
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore Turborepo cache
+        uses: actions/cache@v3
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/package.json', 'pnpm-lock.yaml', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.DS_Store
+dist
+.turbo
+.next
+coverage
+.env*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: up test e2e
+
+up:
+	pnpm dev
+
+test:
+	pnpm test
+
+e2e:
+	pnpm turbo run test --filter=examples-echo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# agentx
+# deterministic-agent-lab
+
+A pnpm + TypeScript monorepo for building deterministic agent tooling, including journal, proxy, trace, and replay packages plus runner and gate applications.
+
+## Workspace layout
+
+- `packages/journal` — shared intent log models and driver SDK helpers.
+- `packages/proxy` — HTTP(S) allowlist proxy with record/replay hooks.
+- `packages/trace` — trace bundle format definitions with readers/writers.
+- `packages/replay` — deterministic replay utilities for network, clock, and RNG.
+- `apps/runner` — CLI entrypoint to run an agent inside a controlled container.
+- `apps/gate-api` — Fastify API surface for plan/approve/commit/revert flows.
+- `apps/gate-ui` — Next.js interface for reviewing diffs and approvals.
+- `examples/agents/echo` — toy agent used for end-to-end tests.
+
+## Getting started
+
+1. Install dependencies (Node 20+ is required):
+
+   ```bash
+   corepack enable pnpm
+   pnpm install
+   ```
+
+2. Run development mode across workspaces:
+
+   ```bash
+   pnpm dev
+   ```
+
+3. Build, lint, and test:
+
+   ```bash
+   pnpm build
+   pnpm lint
+   pnpm test
+   ```
+
+### Makefile shortcuts
+
+- `make up` — alias for `pnpm dev`.
+- `make test` — alias for `pnpm test`.
+- `make e2e` — runs example echo agent tests.
+
+## Tooling
+
+- TypeScript strict configuration shared through `tsconfig.base.json`.
+- ESLint with `@typescript-eslint` rules.
+- Vitest for unit and integration tests.
+- Turborepo orchestrates build/lint/test/dev pipelines with caching.
+- Devcontainer preconfigures Ubuntu, Node 20, Docker-in-Docker, and pnpm.
+
+## Continuous Integration
+
+GitHub Actions workflow installs pnpm, restores pnpm/Turborepo caches, and runs `pnpm lint`, `pnpm build`, and `pnpm test` on every push and pull request.

--- a/apps/gate-api/package.json
+++ b/apps/gate-api/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@deterministic-agent-lab/gate-api",
+  "version": "0.1.0",
+  "main": "dist/server.js",
+  "types": "dist/server.d.ts",
+  "dependencies": {
+    "@deterministic-agent-lab/journal": "workspace:*",
+    "fastify": "^4.25.2"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest run",
+    "dev": "tsx watch src/server.ts"
+  }
+}

--- a/apps/gate-api/src/server.ts
+++ b/apps/gate-api/src/server.ts
@@ -1,0 +1,38 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { Journal } from '@deterministic-agent-lab/journal';
+
+export interface GateApiOptions {
+  readonly journal?: Journal;
+}
+
+export function buildServer(options: GateApiOptions = {}): FastifyInstance {
+  const fastify = Fastify();
+  const journal = options.journal ?? new Journal();
+
+  fastify.post('/plan', async (request, reply) => {
+    const body = (request.body as { id: string; payload: unknown }) ?? {};
+    if (!body.id) {
+      reply.code(400);
+      return { error: 'id is required' };
+    }
+
+    journal.add({
+      id: body.id,
+      timestamp: Date.now(),
+      type: 'plan',
+      payload: body.payload as Record<string, unknown>
+    });
+
+    return { status: 'accepted' };
+  });
+
+  return fastify;
+}
+
+if (require.main === module) {
+  const server = buildServer();
+  server.listen({ port: 3000, host: '0.0.0.0' }).catch((error) => {
+    server.log.error(error);
+    process.exit(1);
+  });
+}

--- a/apps/gate-api/tests/server.test.ts
+++ b/apps/gate-api/tests/server.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { buildServer } from '../src/server';
+
+describe('gate-api server', () => {
+  it('records plans via POST /plan', async () => {
+    const server = buildServer();
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/plan',
+      payload: { id: 'plan-1', payload: { tasks: 2 } }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ status: 'accepted' });
+
+    await server.close();
+  });
+});

--- a/apps/gate-api/tsconfig.json
+++ b/apps/gate-api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "tests"]
+}

--- a/apps/gate-ui/.eslintrc.json
+++ b/apps/gate-ui/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/apps/gate-ui/app/globals.css
+++ b/apps/gate-ui/app/globals.css
@@ -1,0 +1,10 @@
+:root {
+  font-family: system-ui, sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}

--- a/apps/gate-ui/app/layout.tsx
+++ b/apps/gate-ui/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/gate-ui/app/page.tsx
+++ b/apps/gate-ui/app/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+
+const reviews = [
+  { id: 'change-1', title: 'Update docs', status: 'pending' },
+  { id: 'change-2', title: 'Refactor proxy', status: 'approved' }
+];
+
+export default function Page() {
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>Gate Review Queue</h1>
+      <p>Select a change to inspect its deterministic diff.</p>
+      <ul>
+        {reviews.map((review) => (
+          <li key={review.id}>
+            <Link href={`/${review.id}`} prefetch={false}>
+              {review.title} — <strong>{review.status}</strong>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/gate-ui/next-env.d.ts
+++ b/apps/gate-ui/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/gate-ui/next.config.js
+++ b/apps/gate-ui/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/gate-ui/package.json
+++ b/apps/gate-ui/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@deterministic-agent-lab/gate-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "lint": "next lint",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.39",
+    "@types/react-dom": "18.2.17"
+  }
+}

--- a/apps/gate-ui/tests/smoke.test.ts
+++ b/apps/gate-ui/tests/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('gate-ui', () => {
+  it('placeholder test passes', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/apps/gate-ui/tsconfig.json
+++ b/apps/gate-ui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "allowJs": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/runner/package.json
+++ b/apps/runner/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@deterministic-agent-lab/runner",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "deterministic-agent-runner": "dist/index.js"
+  },
+  "dependencies": {
+    "@deterministic-agent-lab/journal": "workspace:*",
+    "@deterministic-agent-lab/replay": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest run",
+    "dev": "tsc --watch --project tsconfig.json --preserveWatchOutput"
+  }
+}

--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -1,0 +1,43 @@
+import { Journal } from '@deterministic-agent-lab/journal';
+import { DeterministicReplay, createSeededRng } from '@deterministic-agent-lab/replay';
+
+export interface RunnerResult {
+  readonly seed: number;
+  readonly outputs: readonly string[];
+}
+
+export function runAgent(seed: number): RunnerResult {
+  const journal = new Journal();
+  const rng = createSeededRng(seed);
+
+  const bundle = {
+    id: `seed-${seed}`,
+    events: Array.from({ length: 3 }, (_, index) => ({
+      timestamp: index,
+      channel: 'rng',
+      data: rng().toFixed(5)
+    }))
+  };
+
+  const replay = new DeterministicReplay(bundle);
+  const outputs: string[] = [];
+  replay.play((event) => {
+    const message = `${event.channel}:${event.data}`;
+    outputs.push(message);
+    journal.add({
+      id: `${bundle.id}-${event.timestamp}`,
+      timestamp: event.timestamp,
+      type: 'rng-sample',
+      payload: { value: event.data }
+    });
+  });
+
+  return { seed, outputs };
+}
+
+if (require.main === module) {
+  const [, , seedArg] = process.argv;
+  const seed = Number(seedArg ?? '1');
+  const result = runAgent(seed);
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/apps/runner/tests/runner.test.ts
+++ b/apps/runner/tests/runner.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { runAgent } from '../src/index';
+
+describe('runAgent', () => {
+  it('produces deterministic outputs for a seed', () => {
+    const first = runAgent(7);
+    const second = runAgent(7);
+
+    expect(first.outputs).toEqual(second.outputs);
+    expect(first.seed).toBe(7);
+  });
+});

--- a/apps/runner/tsconfig.json
+++ b/apps/runner/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "tests"]
+}

--- a/examples/agents/echo/package.json
+++ b/examples/agents/echo/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@deterministic-agent-lab/example-echo",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@deterministic-agent-lab/journal": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest run",
+    "dev": "tsc --watch --project tsconfig.json --preserveWatchOutput"
+  }
+}

--- a/examples/agents/echo/src/index.ts
+++ b/examples/agents/echo/src/index.ts
@@ -1,0 +1,27 @@
+import { Journal } from '@deterministic-agent-lab/journal';
+
+export interface EchoInput {
+  readonly message: string;
+}
+
+export interface EchoResult {
+  readonly echoed: string;
+  readonly journalSize: number;
+}
+
+export function runEchoAgent(input: EchoInput): EchoResult {
+  const journal = new Journal();
+  const normalized = input.message.trim();
+
+  journal.add({
+    id: 'echo-1',
+    timestamp: Date.now(),
+    type: 'echo',
+    payload: { normalized }
+  });
+
+  return {
+    echoed: normalized,
+    journalSize: journal.list().length
+  };
+}

--- a/examples/agents/echo/tests/echo.test.ts
+++ b/examples/agents/echo/tests/echo.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { runEchoAgent } from '../src/index';
+
+describe('runEchoAgent', () => {
+  it('returns a trimmed message and records the interaction', () => {
+    const result = runEchoAgent({ message: '  hello  ' });
+
+    expect(result.echoed).toBe('hello');
+    expect(result.journalSize).toBe(1);
+  });
+});

--- a/examples/agents/echo/tsconfig.json
+++ b/examples/agents/echo/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "tests"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "deterministic-agent-lab",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test",
+    "lint": "turbo run lint",
+    "dev": "turbo run dev --parallel"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.19.1",
+    "@typescript-eslint/parser": "^6.19.1",
+    "eslint": "^8.56.0",
+    "prettier": "^3.1.1",
+    "turbo": "^1.11.3",
+    "typescript": "^5.3.3",
+    "vitest": "^0.34.6",
+    "tsx": "^4.7.0",
+    "@types/node": "20.10.5",
+    "@types/react": "18.2.39",
+    "@types/react-dom": "18.2.17"
+  }
+}

--- a/packages/journal/package.json
+++ b/packages/journal/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@deterministic-agent-lab/journal",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest run",
+    "dev": "tsc --watch --project tsconfig.json --preserveWatchOutput"
+  }
+}

--- a/packages/journal/src/index.ts
+++ b/packages/journal/src/index.ts
@@ -1,0 +1,26 @@
+export interface JournalEntry {
+  readonly id: string;
+  readonly timestamp: number;
+  readonly type: string;
+  readonly payload: Record<string, unknown>;
+}
+
+export class Journal {
+  private readonly entries: JournalEntry[] = [];
+
+  add(entry: JournalEntry): void {
+    if (!entry.id) {
+      throw new Error('JournalEntry requires an id');
+    }
+
+    this.entries.push({ ...entry });
+  }
+
+  list(): readonly JournalEntry[] {
+    return [...this.entries];
+  }
+
+  filterByType(type: string): readonly JournalEntry[] {
+    return this.entries.filter((entry) => entry.type === type);
+  }
+}

--- a/packages/journal/tests/journal.test.ts
+++ b/packages/journal/tests/journal.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { Journal } from '../src/index';
+
+describe('Journal', () => {
+  it('stores and filters entries by type', () => {
+    const journal = new Journal();
+
+    journal.add({
+      id: '1',
+      timestamp: 1,
+      type: 'plan',
+      payload: { steps: 3 }
+    });
+
+    journal.add({
+      id: '2',
+      timestamp: 2,
+      type: 'commit',
+      payload: { success: true }
+    });
+
+    const plans = journal.filterByType('plan');
+    expect(plans).toHaveLength(1);
+    expect(plans[0]?.id).toBe('1');
+  });
+});

--- a/packages/journal/tsconfig.json
+++ b/packages/journal/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "tests"]
+}

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@deterministic-agent-lab/proxy",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest run",
+    "dev": "tsc --watch --project tsconfig.json --preserveWatchOutput"
+  }
+}

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -1,0 +1,17 @@
+export interface ProxyRule {
+  readonly host: string;
+  readonly methods: readonly string[];
+}
+
+export class AllowlistProxy {
+  constructor(private readonly rules: readonly ProxyRule[]) {}
+
+  isAllowed(url: URL, method: string): boolean {
+    const hostRule = this.rules.find((rule) => rule.host === url.host);
+    if (!hostRule) {
+      return false;
+    }
+
+    return hostRule.methods.includes(method.toUpperCase());
+  }
+}

--- a/packages/proxy/tests/proxy.test.ts
+++ b/packages/proxy/tests/proxy.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { AllowlistProxy } from '../src/index';
+
+describe('AllowlistProxy', () => {
+  it('allows only configured methods for a host', () => {
+    const proxy = new AllowlistProxy([
+      { host: 'api.example.com', methods: ['GET', 'POST'] }
+    ]);
+
+    expect(proxy.isAllowed(new URL('https://api.example.com/v1'), 'GET')).toBe(true);
+    expect(proxy.isAllowed(new URL('https://api.example.com/v1'), 'DELETE')).toBe(false);
+    expect(proxy.isAllowed(new URL('https://other.example.com/v1'), 'GET')).toBe(false);
+  });
+});

--- a/packages/proxy/tsconfig.json
+++ b/packages/proxy/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "tests"]
+}

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@deterministic-agent-lab/replay",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@deterministic-agent-lab/trace": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest run",
+    "dev": "tsc --watch --project tsconfig.json --preserveWatchOutput"
+  }
+}

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,0 +1,26 @@
+import type { TraceBundle, TraceEvent } from '@deterministic-agent-lab/trace';
+
+export type ReplayHandler = (event: TraceEvent) => void;
+
+export class DeterministicReplay {
+  constructor(private readonly bundle: TraceBundle) {}
+
+  play(handler: ReplayHandler): void {
+    const ordered = [...this.bundle.events].sort(
+      (left, right) => left.timestamp - right.timestamp
+    );
+
+    for (const event of ordered) {
+      handler(event);
+    }
+  }
+}
+
+export function createSeededRng(seed: number): () => number {
+  let state = seed >>> 0;
+
+  return () => {
+    state = (1664525 * state + 1013904223) % 0x100000000;
+    return state / 0x100000000;
+  };
+}

--- a/packages/replay/tests/replay.test.ts
+++ b/packages/replay/tests/replay.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { DeterministicReplay, createSeededRng } from '../src/index';
+
+describe('DeterministicReplay', () => {
+  it('plays events in timestamp order', () => {
+    const replay = new DeterministicReplay({
+      id: 'bundle',
+      events: [
+        { timestamp: 3, channel: 'log', data: 'late' },
+        { timestamp: 1, channel: 'log', data: 'first' },
+        { timestamp: 2, channel: 'log', data: 'second' }
+      ]
+    });
+
+    const seen: unknown[] = [];
+    replay.play((event) => seen.push(event.data));
+
+    expect(seen).toEqual(['first', 'second', 'late']);
+  });
+});
+
+describe('createSeededRng', () => {
+  it('produces deterministic sequences', () => {
+    const rngA = createSeededRng(42);
+    const rngB = createSeededRng(42);
+
+    expect([rngA(), rngA(), rngA()]).toEqual([rngB(), rngB(), rngB()]);
+  });
+});

--- a/packages/replay/tsconfig.json
+++ b/packages/replay/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "tests"]
+}

--- a/packages/trace/package.json
+++ b/packages/trace/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@deterministic-agent-lab/trace",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest run",
+    "dev": "tsc --watch --project tsconfig.json --preserveWatchOutput"
+  }
+}

--- a/packages/trace/src/index.ts
+++ b/packages/trace/src/index.ts
@@ -1,0 +1,23 @@
+export interface TraceEvent {
+  readonly timestamp: number;
+  readonly channel: string;
+  readonly data: unknown;
+}
+
+export interface TraceBundle {
+  readonly id: string;
+  readonly events: readonly TraceEvent[];
+}
+
+export function serializeTrace(bundle: TraceBundle): string {
+  return JSON.stringify(bundle);
+}
+
+export function parseTrace(payload: string): TraceBundle {
+  const bundle = JSON.parse(payload) as TraceBundle;
+  if (!bundle.id || !Array.isArray(bundle.events)) {
+    throw new Error('Invalid trace payload');
+  }
+
+  return bundle;
+}

--- a/packages/trace/tests/trace.test.ts
+++ b/packages/trace/tests/trace.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { parseTrace, serializeTrace } from '../src/index';
+
+describe('trace bundle', () => {
+  it('round-trips events through JSON', () => {
+    const bundle = {
+      id: 'bundle-1',
+      events: [
+        { timestamp: 1, channel: 'log', data: 'hello' },
+        { timestamp: 2, channel: 'network', data: { status: 200 } }
+      ]
+    } as const;
+
+    const payload = serializeTrace(bundle);
+    const parsed = parseTrace(payload);
+
+    expect(parsed).toEqual(bundle);
+  });
+});

--- a/packages/trace/tsconfig.json
+++ b/packages/trace/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "tests"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "packages/*"
+  - "apps/*"
+  - "examples/*"
+  - "examples/agents/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**", ".next/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
+    "dev": {
+      "cache": false
+    }
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: [
+      'packages/*/tests/**/*.test.ts',
+      'apps/*/tests/**/*.test.ts',
+      'examples/**/tests/**/*.test.ts'
+    ]
+  }
+});


### PR DESCRIPTION
## Summary
- bootstrap the deterministic-agent-lab pnpm monorepo with shared TypeScript tooling and Turborepo orchestration
- add journal, proxy, trace, replay packages plus runner, gate-api, gate-ui apps and an echo example agent with starter source and tests
- provide developer ergonomics via devcontainer, Makefile shortcuts, CI workflow, and README documentation

## Testing
- ⚠️ `pnpm install` *(fails: npm registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cee1ed66948330a205080a400c5f08